### PR TITLE
fix: nuxt demo w/ alias

### DIFF
--- a/demo/nuxt.config.ts
+++ b/demo/nuxt.config.ts
@@ -1,6 +1,11 @@
+import path from 'node:path'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   devtools: { enabled: true },
+  alias: {
+    'vue-email': path.resolve(__dirname, '../packages/vue-email/src'),
+  },
   modules: ['@nuxthq/ui', 'vue-email/nuxt'],
   typescript: {
     shim: false,


### PR DESCRIPTION
In this PR I fixed the issue where the demo would break when developing since it's in a mono repo.