### PR TITLE
refactor: changed from isomorphic-dompurify to sanitize-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
   },
   "dependencies": {
     "html-to-text": "^9.0.5",
-    "isomorphic-dompurify": "^1.8.0",
     "module-from-string": "^3.3.0",
     "node-html-parser": "^6.1.5",
-    "pretty": "^2.0.0"
+    "pretty": "^2.0.0",
+    "sanitize-html": "^2.11.0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {
@@ -93,12 +93,12 @@
     }
   },
   "devDependencies": {
-    "vue-email": "workspace:*",
     "@antfu/eslint-config": "^0.39.8",
     "@nuxt/kit": "^3.6.5",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@types/html-to-text": "^9.0.1",
     "@types/pretty": "^2.0.1",
+    "@types/sanitize-html": "^2.9.0",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vitest/coverage-v8": "^0.33.0",
     "changelogen": "^0.5.4",
@@ -117,6 +117,7 @@
     "vite-plugin-banner": "^0.7.0",
     "vite-plugin-dts": "^3.3.1",
     "vitest": "^0.33.0",
-    "vue": "^3.3.4"
+    "vue": "^3.3.4",
+    "vue-email": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
-      isomorphic-dompurify:
-        specifier: ^1.8.0
-        version: 1.8.0
       module-from-string:
         specifier: ^3.3.0
         version: 3.3.0
@@ -23,6 +20,9 @@ importers:
       pretty:
         specifier: ^2.0.0
         version: 2.0.0
+      sanitize-html:
+        specifier: ^2.11.0
+        version: 2.11.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^0.39.8
@@ -39,6 +39,9 @@ importers:
       '@types/pretty':
         specifier: ^2.0.1
         version: 2.0.1
+      '@types/sanitize-html':
+        specifier: ^2.9.0
+        version: 2.9.0
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
         version: 4.2.3(vite@4.4.7)(vue@3.3.4)
@@ -104,7 +107,7 @@ importers:
     dependencies:
       '@nuxt/devtools-ui-kit':
         specifier: ^0.7.1
-        version: 0.7.1(@nuxt/devtools@0.7.5)(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.26.3)(vite@4.4.7)(vue@3.3.4)(webpack@5.88.2)
+        version: 0.7.1(@nuxt/devtools@0.8.0)(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.26.3)(vite@4.4.7)(vue@3.3.4)(webpack@5.88.2)
     devDependencies:
       '@iconify-json/heroicons':
         specifier: ^1.1.11
@@ -114,7 +117,7 @@ importers:
         version: 1.1.5
       '@nuxt/devtools':
         specifier: latest
-        version: 0.7.5(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
+        version: 0.8.0(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
       '@nuxthq/ui':
         specifier: ^2.6.0
         version: 2.6.0(rollup@3.26.3)(vue@3.3.4)(webpack@5.88.2)
@@ -141,7 +144,7 @@ importers:
         version: 1.1.5
       '@iconify-json/simple-icons':
         specifier: latest
-        version: 1.1.65
+        version: 1.1.66
       '@iconify-json/twemoji':
         specifier: latest
         version: 1.1.12
@@ -198,7 +201,7 @@ importers:
         version: 1.1.5
       '@nuxt/devtools':
         specifier: latest
-        version: 0.7.5(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
+        version: 0.8.0(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
       '@nuxthq/ui':
         specifier: ^2.6.0
         version: 2.6.0(rollup@3.26.3)(vue@3.3.4)(webpack@5.88.2)
@@ -1168,8 +1171,8 @@ packages:
       '@iconify/types': 2.0.0
     dev: false
 
-  /@iconify-json/simple-icons@1.1.65:
-    resolution: {integrity: sha512-pCL5nF80e5YrvnR9VFt7EROEcWE6vvtBaThx+hC1Xaw3e1DkCTc4JioiNnYrON/p2iNVvncAQAgQP1Us/XPInw==}
+  /@iconify-json/simple-icons@1.1.66:
+    resolution: {integrity: sha512-sDqdt8xigpzmYqtQIDYNfhXUyNMwxW3OniklPmlV//9Jk4+iddFd5vT0rpSp4ivylp/lAwPwe22IR63KL0eSEg==}
     dependencies:
       '@iconify/types': 2.0.0
     dev: true
@@ -1499,8 +1502,8 @@ packages:
       - supports-color
     dev: false
 
-  /@nuxt/devtools-kit@0.7.5(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7):
-    resolution: {integrity: sha512-Zadd4s2vHlFQYRBLqmCADLMs1qxht8KKCZzfdhEdCAHby/s3EkfnYIuRUBlrfuAuNxa4cyExKFpeDpQ67N5fIQ==}
+  /@nuxt/devtools-kit@0.8.0(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7):
+    resolution: {integrity: sha512-zHwotLFwmYPFDg0JHyInn0L3i2gZK24JYDfgOzqBuvCD/Q3ytQVyAMrX2Mp4iIrHjwToZBJ0dlyV+UYXCiWwSg==}
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
@@ -1514,7 +1517,7 @@ packages:
       - rollup
       - supports-color
 
-  /@nuxt/devtools-ui-kit@0.7.1(@nuxt/devtools@0.7.5)(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.26.3)(vite@4.4.7)(vue@3.3.4)(webpack@5.88.2):
+  /@nuxt/devtools-ui-kit@0.7.1(@nuxt/devtools@0.8.0)(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.26.3)(vite@4.4.7)(vue@3.3.4)(webpack@5.88.2):
     resolution: {integrity: sha512-g1PXqaIIK76U8Aw2+wRu6ETEKz9hTVvqA4NmqdogzpE4vf0gbO050np4kzZJ8ToPWm8o5WRk5kdn4ZgfTWhcVA==}
     peerDependencies:
       '@nuxt/devtools': 0.7.1
@@ -1523,7 +1526,7 @@ packages:
       '@iconify-json/logos': 1.1.33
       '@iconify-json/ri': 1.1.10
       '@iconify-json/tabler': 1.1.85
-      '@nuxt/devtools': 0.7.5(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
+      '@nuxt/devtools': 0.8.0(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
       '@nuxt/devtools-kit': 0.7.1(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
       '@nuxt/kit': 3.6.5(rollup@3.26.3)
       '@nuxtjs/color-mode': 3.3.0(rollup@3.26.3)
@@ -1580,8 +1583,8 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /@nuxt/devtools-wizard@0.7.5:
-    resolution: {integrity: sha512-A8Urgy3hJBi3MSDEsr3yzOhO1jHoE80cQHmQUqAD8sD2e2fQSOwaH5CZMVGPbnSCWDfbchy+1cCwJ30JuEfeKg==}
+  /@nuxt/devtools-wizard@0.8.0:
+    resolution: {integrity: sha512-nxYAB4TQgeaoYY3xBEzrYVpXzXUAwoeCui0vqu1oTeeuKnl62uXFGsY4vXMHQtnibvbQVZzNFVFoXggKM3MBGw==}
     hasBin: true
     dependencies:
       consola: 3.2.3
@@ -1647,15 +1650,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@nuxt/devtools@0.7.5(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7):
-    resolution: {integrity: sha512-Uxjow3J0QcYnbgMA8XR/1myr6Nw8P5vA/PMxTTj8LKqSZhd2+BgjnAg1gRUmMeKQCvkUfNOD+AqTK2HOBdHaBw==}
+  /@nuxt/devtools@0.8.0(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7):
+    resolution: {integrity: sha512-w48eqZ52NLVB8C0Q1E/eY0xsokMr9diOaxUptO08UYNhyj+MKKBrhIBTePYO7GlxabXOaHM62zi+iN8AT1qXoA==}
     hasBin: true
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
     dependencies:
-      '@nuxt/devtools-kit': 0.7.5(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
-      '@nuxt/devtools-wizard': 0.7.5
+      '@nuxt/devtools-kit': 0.8.0(nuxt@3.6.5)(rollup@3.26.3)(vite@4.4.7)
+      '@nuxt/devtools-wizard': 0.8.0
       '@nuxt/kit': 3.6.5(rollup@3.26.3)
       birpc: 0.2.12
       boxen: 7.1.1
@@ -1686,7 +1689,7 @@ packages:
       unimport: 3.1.3(rollup@3.26.3)
       vite: 4.4.7(@types/node@20.4.5)
       vite-plugin-inspect: 0.7.35(@nuxt/kit@3.6.5)(rollup@3.26.3)(vite@4.4.7)
-      vite-plugin-vue-inspector: 3.5.0(vite@4.4.7)
+      vite-plugin-vue-inspector: 3.6.0(vite@4.4.7)
       wait-on: 7.0.1
       which: 3.0.1
       ws: 8.13.0
@@ -1749,7 +1752,7 @@ packages:
       postcss-import-resolver: 2.0.0
       std-env: 3.3.3
       ufo: 1.1.2
-      unimport: 3.1.0(rollup@3.26.3)
+      unimport: 3.1.3(rollup@3.26.3)
       untyped: 1.3.2
     transitivePeerDependencies:
       - rollup
@@ -1765,7 +1768,7 @@ packages:
       consola: 3.2.3
       create-require: 1.1.1
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       dotenv: 16.3.1
       fs-extra: 11.1.1
       git-url-parse: 13.1.0
@@ -1819,8 +1822,8 @@ packages:
       postcss-url: 10.1.3(postcss@8.4.27)
       rollup-plugin-visualizer: 5.9.2(rollup@3.26.3)
       std-env: 3.3.3
-      strip-literal: 1.0.1
-      ufo: 1.1.2
+      strip-literal: 1.3.0
+      ufo: 1.2.0
       unplugin: 1.4.0
       vite: 4.3.9(@types/node@20.4.5)
       vite-node: 0.33.0(@types/node@20.4.5)
@@ -2002,7 +2005,7 @@ packages:
       colorette: 2.0.20
       cookie-es: 1.0.0
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       h3: 1.7.1
       iron-webcrypto: 0.7.1
       micromatch: 4.0.5
@@ -2013,7 +2016,7 @@ packages:
       radix3: 1.0.1
       tailwind-config-viewer: 1.7.2(tailwindcss@3.3.3)
       tailwindcss: 3.3.3
-      ufo: 1.1.2
+      ufo: 1.2.0
       uncrypto: 0.1.3
     transitivePeerDependencies:
       - rollup
@@ -2369,12 +2372,6 @@ packages:
       '@types/ms': 0.7.31
     dev: true
 
-  /@types/dompurify@3.0.2:
-    resolution: {integrity: sha512-YBL4ziFebbbfQfH5mlC+QTJsvh0oJUrWbmxKMyEdL7emlHJqGR2Qb34TEFKj+VCayBvjKy3xczMFNhugThUsfQ==}
-    dependencies:
-      '@types/trusted-types': 2.0.3
-    dev: false
-
   /@types/eslint-scope@3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
@@ -2458,13 +2455,15 @@ packages:
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  /@types/sanitize-html@2.9.0:
+    resolution: {integrity: sha512-4fP/kEcKNj2u39IzrxWYuf/FnCCwwQCpif6wwY6ROUS1EPRIfWJjGkY3HIowY1EX/VbX5e86yq8AAE7UPMgATg==}
+    dependencies:
+      htmlparser2: 8.0.2
+    dev: true
+
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: true
-
-  /@types/trusted-types@2.0.3:
-    resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
-    dev: false
 
   /@types/unist@2.0.7:
     resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
@@ -3102,7 +3101,7 @@ packages:
   /@vitest/snapshot@0.33.0:
     resolution: {integrity: sha512-tJjrl//qAHbyHajpFvr8Wsk8DIOODEebTu7pgBrP07iOepR5jYkLFiqLq2Ltxv+r0uptUb4izv1J8XBOwKkVYA==}
     dependencies:
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
       pretty-format: 29.6.2
     dev: true
@@ -3203,7 +3202,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       postcss: 8.4.27
       source-map-js: 1.0.2
 
@@ -3528,10 +3527,6 @@ packages:
 
   /@xtuc/long@4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
-
-  /abab@2.0.6:
-    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    dev: false
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -4608,13 +4603,6 @@ packages:
     dependencies:
       css-tree: 2.2.1
 
-  /cssstyle@3.0.0:
-    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
-    engines: {node: '>=14'}
-    dependencies:
-      rrweb-cssom: 0.6.0
-    dev: false
-
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
@@ -4624,15 +4612,6 @@ packages:
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  /data-urls@4.0.0:
-    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
-    engines: {node: '>=14'}
-    dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 12.0.1
-    dev: false
 
   /de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -4669,10 +4648,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-
-  /decimal.js@10.4.3:
-    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
-    dev: false
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -4894,22 +4869,11 @@ packages:
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
-  /domexception@4.0.0:
-    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
-    engines: {node: '>=12'}
-    dependencies:
-      webidl-conversions: 7.0.0
-    dev: false
-
   /domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
-
-  /dompurify@3.0.5:
-    resolution: {integrity: sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A==}
-    dev: false
 
   /domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -6066,7 +6030,7 @@ packages:
       enhanced-resolve: 5.15.0
       mlly: 1.4.0
       pathe: 1.1.1
-      ufo: 1.1.2
+      ufo: 1.2.0
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -6195,9 +6159,9 @@ packages:
       '@capsizecss/metrics': 1.2.0
       '@capsizecss/unpack': 1.0.0
       magic-regexp: 0.7.0
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
-      ufo: 1.1.2
+      ufo: 1.2.0
       unplugin: 1.4.0
     transitivePeerDependencies:
       - encoding
@@ -6539,7 +6503,7 @@ packages:
       deepmerge: 4.3.1
       hookable: 5.5.3
       ofetch: 1.1.1
-      ufo: 1.1.2
+      ufo: 1.2.0
     dev: true
 
   /gopd@1.0.1:
@@ -6743,13 +6707,6 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       lru-cache: 7.18.3
-
-  /html-encoding-sniffer@3.0.0:
-    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
-    engines: {node: '>=12'}
-    dependencies:
-      whatwg-encoding: 2.0.0
-    dev: false
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -7197,8 +7154,9 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /is-potential-custom-element-name@1.0.1:
-    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+  /is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /is-primitive@3.0.1:
@@ -7291,19 +7249,6 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  /isomorphic-dompurify@1.8.0:
-    resolution: {integrity: sha512-qvNsRVUQIArrn7/TNDw0+0wQgtvRxAkSzfe0pGpX1+OYeGhrAWELxZIb6x+KFFRS6mb4OUe+zAK9yp0WDZHUdQ==}
-    dependencies:
-      '@types/dompurify': 3.0.2
-      dompurify: 3.0.5
-      jsdom: 22.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: false
-
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
@@ -7390,44 +7335,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-
-  /jsdom@22.1.0:
-    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    dependencies:
-      abab: 2.0.6
-      cssstyle: 3.0.0
-      data-urls: 4.0.0
-      decimal.js: 10.4.3
-      domexception: 4.0.0
-      form-data: 4.0.0
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.7
-      parse5: 7.1.2
-      rrweb-cssom: 0.6.0
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.3
-      w3c-xmlserializer: 4.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 12.0.1
-      ws: 8.13.0
-      xml-name-validator: 4.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
 
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -7642,7 +7549,7 @@ packages:
       mlly: 1.4.0
       node-forge: 1.3.1
       pathe: 1.1.1
-      ufo: 1.1.2
+      ufo: 1.2.0
 
   /listhen@1.2.2:
     resolution: {integrity: sha512-fQaXe+DAQ5QiYP1B4uXfAgwqIwNS+0WMIwRd5l2a3npQAEhlCJ1pN11d41yHtbeReE7oRtfL+h6Nzxq+Wc4vIg==}
@@ -7794,7 +7701,7 @@ packages:
       magic-string: 0.30.2
       mlly: 1.4.0
       type-level-regexp: 0.1.17
-      ufo: 1.1.2
+      ufo: 1.2.0
       unplugin: 1.4.0
     dev: true
 
@@ -8584,7 +8491,7 @@ packages:
       consola: 3.2.3
       cookie-es: 1.0.0
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       dot-prop: 7.2.0
       esbuild: 0.18.17
       escape-string-regexp: 5.0.0
@@ -8622,10 +8529,10 @@ packages:
       serve-static: 1.15.0
       source-map-support: 0.5.21
       std-env: 3.3.3
-      ufo: 1.1.2
+      ufo: 1.2.0
       uncrypto: 0.1.3
       unenv: 1.5.2
-      unimport: 3.1.0(rollup@3.26.3)
+      unimport: 3.1.3(rollup@3.26.3)
       unstorage: 1.9.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8978,10 +8885,6 @@ packages:
       - vti
       - vue-tsc
 
-  /nwsapi@2.2.7:
-    resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
-    dev: false
-
   /nypm@0.2.2:
     resolution: {integrity: sha512-O7bumfWgUXlJefT1Y41SF4vsCvzeUYmnKABuOKStheCObzrkWPDmqJc+RJVU+57oFu9bITcrUq8sKFIHgjCnTg==}
     engines: {node: ^14.16.0 || >=16.10.0}
@@ -9249,6 +9152,10 @@ packages:
     dependencies:
       protocols: 2.0.1
 
+  /parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+    dev: false
+
   /parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
     dependencies:
@@ -9257,12 +9164,6 @@ packages:
   /parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: true
-
-  /parse5@7.1.2:
-    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
-    dependencies:
-      entities: 4.5.0
-    dev: false
 
   /parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -9979,17 +9880,9 @@ packages:
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
-  /psl@1.9.0:
-    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
-    dev: false
-
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
-
-  /querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -10370,10 +10263,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /rrweb-cssom@0.6.0:
-    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
-    dev: false
-
   /run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
     engines: {node: '>=12'}
@@ -10431,11 +10320,15 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     requiresBuild: true
 
-  /saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
+  /sanitize-html@2.11.0:
+    resolution: {integrity: sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==}
     dependencies:
-      xmlchars: 2.2.0
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.4.27
     dev: false
 
   /schema-utils@3.3.0:
@@ -10897,10 +10790,6 @@ packages:
       csso: 5.0.5
       picocolors: 1.0.0
 
-  /symbol-tree@3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: false
-
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -11146,25 +11035,8 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  /tough-cookie@4.1.3:
-    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
-    engines: {node: '>=6'}
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.3.0
-      universalify: 0.2.0
-      url-parse: 1.5.10
-    dev: false
-
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  /tr46@4.1.1:
-    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
-    engines: {node: '>=14'}
-    dependencies:
-      punycode: 2.3.0
-    dev: false
 
   /trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -11619,11 +11491,6 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
-  /universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-    dev: false
-
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
@@ -11733,7 +11600,7 @@ packages:
     dependencies:
       anymatch: 3.1.3
       chokidar: 3.5.3
-      destr: 2.0.0
+      destr: 2.0.1
       h3: 1.7.1
       ioredis: 5.3.2
       listhen: 1.1.2
@@ -11741,7 +11608,7 @@ packages:
       mri: 1.2.0
       node-fetch-native: 1.2.0
       ofetch: 1.1.1
-      ufo: 1.1.2
+      ufo: 1.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11830,13 +11697,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-
-  /url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -12081,6 +11941,25 @@ packages:
       vite: 4.4.7(@types/node@20.4.5)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite-plugin-vue-inspector@3.6.0(vite@4.4.7):
+    resolution: {integrity: sha512-Fi+9JaMx/reuic+MWbrdw8g5TwZM5a/BmdBT8OKKZi3rK4Qw3wND9smT+Ld+Daitbgly17uvuCiull2KV/hEBQ==}
+    peerDependencies:
+      vite: ^3.0.0-0 || ^4.0.0-0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-transform-typescript': 7.22.9(@babel/core@7.22.9)
+      '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.22.9)
+      '@vue/compiler-dom': 3.3.4
+      esno: 0.16.3
+      kolorist: 1.8.0
+      magic-string: 0.30.2
+      shell-quote: 1.8.1
+      vite: 4.4.7(@types/node@20.4.5)
+    transitivePeerDependencies:
+      - supports-color
 
   /vite@4.3.9(@types/node@20.4.5):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
@@ -12251,7 +12130,7 @@ packages:
   /vue-bundle-renderer@1.0.3:
     resolution: {integrity: sha512-EfjX+5TTUl70bki9hPuVp+54JiZOvFIfoWBcfXsSwLzKEiDYyHNi5iX8srnqLIv3YRnvxgbntdcG1WPq0MvffQ==}
     dependencies:
-      ufo: 1.1.2
+      ufo: 1.2.0
 
   /vue-component-meta@1.8.8(typescript@5.1.6):
     resolution: {integrity: sha512-iVwH7wGm6VpOAvQoMjFmv8Coe9oV61JqbRkUVx95Xegwb3hEYmltvv4hYvLwUjaev07JRkskPQctyzPBU3YFyQ==}
@@ -12352,13 +12231,6 @@ packages:
       '@vue/server-renderer': 3.3.4(vue@3.3.4)
       '@vue/shared': 3.3.4
 
-  /w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
-    dependencies:
-      xml-name-validator: 4.0.0
-    dev: false
-
   /wait-on@7.0.1:
     resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
     engines: {node: '>=12.0.0'}
@@ -12393,6 +12265,7 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+    dev: true
 
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -12445,18 +12318,12 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
+    dev: true
 
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
-
-  /whatwg-url@12.0.1:
-    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      tr46: 4.1.1
-      webidl-conversions: 7.0.0
-    dev: false
+    dev: true
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -12565,10 +12432,7 @@ packages:
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
-
-  /xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: false
+    dev: true
 
   /xmlhttprequest-ssl@2.0.0:
     resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}

--- a/src/compiler/template.ts
+++ b/src/compiler/template.ts
@@ -4,8 +4,8 @@ import { renderToString } from 'vue/server-renderer'
 import { blue, bold, lightGreen } from 'kolorist'
 import { importFromStringSync } from 'module-from-string'
 import type { Component } from 'vue'
-import type { Options, RenderOptions } from '../types/compiler'
 import { VueEmailPlugin } from 'vue-email'
+import type { Options, RenderOptions } from '../types/compiler'
 
 const scriptIdentifier = '_sfc_main'
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,15 +1,8 @@
-import DOMPurify from 'isomorphic-dompurify'
 import type { CSSProperties } from 'vue'
+import sanitizeHtml from 'sanitize-html'
 import type { StylesType } from '../types/markdown'
 import { styles } from './styles'
 import { patterns } from './patterns'
-
-// hook to handle target="_blank" in all links
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if ('target' in node) {
-    node.setAttribute('target', '_blank')
-  }
-})
 
 export function camelToKebabCase(str: string): string {
   return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
@@ -222,7 +215,24 @@ export function parseMarkdownToVueEmailJSX(markdown: string, customStyles: Style
     `<hr${withDataAttr ? ' data-id="vue-email-hr"' : ''}${parseCssInJsToInlineCss(finalStyles.hr) !== '' ? ` style="${parseCssInJsToInlineCss(finalStyles.hr)}"` : ''}/>`,
   )
 
-  return DOMPurify.sanitize(vueMailTemplate, {
-    USE_PROFILES: { html: true },
+  return sanitizeHtml(vueMailTemplate, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['del', 'blockquote']),
+    allowedAttributes: {
+      h1: ['style', 'data-id'],
+      h2: ['style', 'data-id'],
+      h3: ['style', 'data-id'],
+      h4: ['style', 'data-id'],
+      h5: ['style', 'data-id'],
+      h6: ['style', 'data-id'],
+      a: ['href', 'style', 'target', 'data-id'],
+      p: ['style', 'data-id'],
+      strong: ['style', 'data-id'],
+      td: ['align'],
+      th: ['align'],
+      em: ['style', 'data-id'],
+    },
+    transformTags: {
+      a: sanitizeHtml.simpleTransform('a', { target: '_blank' }),
+    },
   })
 }

--- a/tests/Markdown.spec.ts
+++ b/tests/Markdown.spec.ts
@@ -16,7 +16,7 @@ describe('Markdown component renders correctly', () => {
     const actualOutput = await useRender(component)
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\"><h1 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:2.5rem\\">This is a <del>chair</del> Table</h1><table><thead><tr><th align=\\"center\\">Heading 1</th><th align=\\"center\\">Heading 2</th></tr></thead><tbody><tr><td align=\\"center\\">Cell 1</td><td align=\\"center\\">Cell 2</td></tr><tr><td align=\\"center\\">Cell 3</td><td align=\\"center\\">Cell 4</td></tr></tbody></table></div>"',
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\"><h1 style=\\"font-weight:500;padding-top:20;font-size:2.5rem\\" data-id=\\"vue-email-heading\\">This is a <del>chair</del> Table</h1><table><thead><tr><th align=\\"center\\">Heading 1</th><th align=\\"center\\">Heading 2</th></tr></thead><tbody><tr><td align=\\"center\\">Cell 1</td><td align=\\"center\\">Cell 2</td></tr><tr><td align=\\"center\\">Cell 3</td><td align=\\"center\\">Cell 4</td></tr></tbody></table></div>"',
     )
   })
 
@@ -36,12 +36,12 @@ describe('Markdown component renders correctly', () => {
 
     expect(actualOutput).toMatchInlineSnapshot(
       `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\">
-<h1 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:2.5rem\\">Heading 1!</h1>
-<h2 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:2rem\\">Heading 2!</h2>
-<h3 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:1.75rem\\">Heading 3!</h3>
-<h4 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:1.5rem\\">Heading 4!</h4>
-<h5 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:1.25rem\\">Heading 5!</h5>
-<h6 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:1rem\\">Heading 6!</h6>
+<h1 style=\\"font-weight:500;padding-top:20;font-size:2.5rem\\" data-id=\\"vue-email-heading\\">Heading 1!</h1>
+<h2 style=\\"font-weight:500;padding-top:20;font-size:2rem\\" data-id=\\"vue-email-heading\\">Heading 2!</h2>
+<h3 style=\\"font-weight:500;padding-top:20;font-size:1.75rem\\" data-id=\\"vue-email-heading\\">Heading 3!</h3>
+<h4 style=\\"font-weight:500;padding-top:20;font-size:1.5rem\\" data-id=\\"vue-email-heading\\">Heading 4!</h4>
+<h5 style=\\"font-weight:500;padding-top:20;font-size:1.25rem\\" data-id=\\"vue-email-heading\\">Heading 5!</h5>
+<h6 style=\\"font-weight:500;padding-top:20;font-size:1rem\\" data-id=\\"vue-email-heading\\">Heading 6!</h6>
 </div>"`,
     )
   })
@@ -54,7 +54,7 @@ describe('Markdown component renders correctly', () => {
     const actualOutput = await useRender(component)
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\"><strong data-id=\\"vue-email-text\\" style=\\"font-weight:bold\\">This is sample bold text in markdown</strong> and <em data-id=\\"vue-email-text\\" style=\\"font-style:italic\\">this is italic text</em></div>"',
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\"><strong style=\\"font-weight:bold\\" data-id=\\"vue-email-text\\">This is sample bold text in markdown</strong> and <em style=\\"font-style:italic\\" data-id=\\"vue-email-text\\">this is italic text</em></div>"',
     )
   })
 
@@ -66,7 +66,7 @@ describe('Markdown component renders correctly', () => {
     const actualOutput = await useRender(component)
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\"><p data-id=\\"vue-email-text\\">Link to <a href=\\"https://vue-email.vercel.app/\\" style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\" data-id=\\"vue-email-link\\" target=\\"_blank\\">Vue`-email</a></p></div>"',
+      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"vue-email-link\\" data-id=\\"__vue-email-markdown\\" style=\\"\\"><p data-id=\\"vue-email-text\\">Link to <a  style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\" href=\\"https://vue-email.vercel.app/\\" target=\\"_blank\\">Vue`-email</a></p></div>"',
     )
   })
 
@@ -85,7 +85,7 @@ describe('Markdown component renders correctly', () => {
 
     expect(actualOutput).toMatchInlineSnapshot(
       `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"__vue-email-markdown\\" style=\\"\\">
-<h1 data-id=\\"vue-email-heading\\" style=\\"font-weight:500;padding-top:20;font-size:2.5rem\\">Below is a list</h1>
+<h1 style=\\"font-weight:500;padding-top:20;font-size:2.5rem\\" data-id=\\"vue-email-heading\\">Below is a list</h1>
 <ul><li>Item One</li>
 <li>Item Two</li>
 <li>Item Three</li></ul>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
       include: [resolve(__dirname, 'src')],
     },
     rollupOptions: {
-      external: ['vue', 'html-to-text', 'pretty', 'isomorphic-dompurify', 'node-html-parser'],
+      external: ['vue', 'html-to-text', 'pretty', 'node-html-parser', 'sanitize-html'],
       output: {
         exports: 'named',
         globals: {


### PR DESCRIPTION
I changed the _isomorphic-dompurify_ lib to sanitize-html.

I might have not catched all allow tags/attributes so I would need some help there.

I had to changed the order of attributes so thats why I changed the tests.

But there is one test I am not able to fix rn.
**renders links in the correct format for browsers**

File: _Markdown.spec.ts:61_

```ts
...
    expect(actualOutput).toMatchInlineSnapshot(
      '"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div data-id=\\"vue-email-link\\" data-id=\\"__vue-email-markdown\\" style=\\"\\"><p data-id=\\"vue-email-text\\">Link to <a  style=\\"color:#007bff;text-decoration:underline;background-color:transparent\\" href=\\"https://vue-email.vercel.app/\\" target=\\"_blank\\">Vue`-email</a></p></div>"',
    )
```

You see there are two data-id attr on the div tag which get sanitized.
`data-id=\\"vue-email-link\\" data-id=\\"__vue-email-markdown\\"`

TODO:
* Fix tests
* Improve and add missing tags/attr the list of **allowedTags** and **allowedAttributes**