### PR TITLE
docs: Updated Sendgrid integration

### DIFF
--- a/docs/content/5.integrations/sendgrid.md
+++ b/docs/content/5.integrations/sendgrid.md
@@ -64,7 +64,7 @@ export default defineEventHandler(async (event) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: body.template,
+    html: template,
   };
 
   await sendgrid.send(options);


### PR DESCRIPTION
Remove `body` object used to set html option passed to sendgrid send method.