### PR TITLE
feat: added `text` to the renderd ssr

### DIFF
--- a/client/components/EmailPreview.vue
+++ b/client/components/EmailPreview.vue
@@ -68,7 +68,7 @@ watchEffect(() => {
         <UTooltip text="Change View to Desktop">
           <UButton icon="i-heroicons-computer-desktop" size="sm" color="gray" variant="solid" :trailing="false" @click="handleView('desktop')" />
         </UTooltip>
-        <UTooltip text="Get HTML/PlainText Code">
+        <UTooltip text="Get HTML/Text Code">
           <UButton
             icon="i-heroicons-code-bracket"
             size="sm"

--- a/client/composables/useEmail.ts
+++ b/client/composables/useEmail.ts
@@ -33,7 +33,7 @@ export function useEmail() {
 
     const { data } = await useFetch<{
       html: string
-      plainText: string
+      text: string
     }>(`/api/render/${email.value.filename}`, {
       baseURL: host.value,
     })
@@ -42,7 +42,7 @@ export function useEmail() {
       return {
         vue: email.value.content,
         html: pretty(data.value.html),
-        txt: data.value.plainText,
+        txt: data.value.text,
       }
 
     return null

--- a/client/composables/useEmail.ts
+++ b/client/composables/useEmail.ts
@@ -1,5 +1,4 @@
 import pretty from 'pretty'
-import { convert } from 'html-to-text'
 import type { Email } from '@/types/email'
 import { host } from '@/util/logic'
 
@@ -32,20 +31,18 @@ export function useEmail() {
   const renderEmail = async () => {
     if (!email.value) return null
 
-    const { data } = await useFetch<string>(`/api/render/${email.value.filename}`, {
+    const { data } = await useFetch<{
+      html: string
+      plainText: string
+    }>(`/api/render/${email.value.filename}`, {
       baseURL: host.value,
     })
 
     if (data.value)
       return {
         vue: email.value.content,
-        html: pretty(data.value),
-        txt: convert(data.value, {
-          selectors: [
-            { selector: 'img', format: 'skip' },
-            { selector: '#__vue-email-preview', format: 'skip' },
-          ],
-        }),
+        html: pretty(data.value.html),
+        txt: data.value.plainText,
       }
 
     return null

--- a/docs/content/1.getting-started/3.SSR.md
+++ b/docs/content/1.getting-started/3.SSR.md
@@ -86,6 +86,17 @@ To use `Vue Email` on the server side, you need to install the `vue-email` packa
 NOTE: `vue email` auto imports its components, so you do not need to import them manually in your templates. [More Info](https://github.com/Dave136/vue-email/issues/51#issuecomment-1678738526)
 ::
 
+## Output
+
+The `render` method returns an object with two properties, `html` and `text`. The `html` property contains the HTML version of the email, and the `text` property contains the text version of the email.
+
+```json
+{
+  "html": "<!DOCTYPE html> ...",
+  "text": "Welcome John Doe"
+}
+```
+
 ## 📧 Node Usage
 
 ### Config
@@ -147,7 +158,7 @@ app.get("/", async function (req, res) {
       name: "John Doe",
     },
   });
-  res.send(template);
+  res.send(template.html);
 });
 
 app.listen(3000);

--- a/docs/content/4.utilities/1.Render.md
+++ b/docs/content/4.utilities/1.Render.md
@@ -74,7 +74,7 @@ Here’s how to convert a Vue component into plain text.
   import template from '~/components/template.vue';
 
   const text = await useRender(template, null, {
-    plainText: true,
+    text: true,
   });
 
   console.log(text);
@@ -100,7 +100,7 @@ meta:
   - name: "pretty"
     description: "Beautify HTML output"
     type: "boolean"
-  - name: "plainText"
+  - name: "text"
     description: "Generate plain text version"
     type: "boolean"
 ---

--- a/docs/content/5.integrations/aws-ses.md
+++ b/docs/content/5.integrations/aws-ses.md
@@ -72,7 +72,7 @@ export default defineEventHandler(async (event) => {
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: template,
+          Data: template.html,
         },
       },
       Subject: {
@@ -115,7 +115,7 @@ app.post('/api/send-email', async (req, res) => {
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: template,
+          Data: template.html,
         },
       },
       Subject: {

--- a/docs/content/5.integrations/mailersend.md
+++ b/docs/content/5.integrations/mailersend.md
@@ -74,7 +74,7 @@ export default defineEventHandler(async (event) => {
   .setFrom(sentFrom)
   .setTo(recipients)
   .setSubject("This is a Subject")
-  .setHtml(template)
+  .setHtml(template.html)
 
 
   await mailerSend.email.send(options);
@@ -112,7 +112,7 @@ app.post('/api/send-email', async (req, res) => {
   .setFrom(sentFrom)
   .setTo(recipients)
   .setSubject("This is a Subject")
-  .setHtml(template)
+  .setHtml(template.html)
 
   await mailerSend.email.send(options);
 

--- a/docs/content/5.integrations/nodemailer.md
+++ b/docs/content/5.integrations/nodemailer.md
@@ -76,7 +76,7 @@ export default defineEventHandler(async (event) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: template,
+    html: template.html,
   };
 
   await transporter.sendMail(options);
@@ -117,7 +117,7 @@ app.post('/api/send-email', async (req, res) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: template,
+    html: template.html,
   };
 
   await transporter.sendMail(options);

--- a/docs/content/5.integrations/plunk.md
+++ b/docs/content/5.integrations/plunk.md
@@ -65,7 +65,7 @@ export default defineEventHandler(async (event) => {
   await plunk.emails.send({
     to: "hello@useplunk.com",
     subject: "Hello world",
-    body: template,
+    body: template.html,
   });
 
   return { message: 'Email sent' };
@@ -94,7 +94,7 @@ app.post('/api/send-email', async (req, res) => {
   await plunk.emails.send({
     to: "hello@useplunk.com",
     subject: "Hello world",
-    body: template,
+    body: template.html,
   });
 
   return res.json({ message: "Email sent" });

--- a/docs/content/5.integrations/postmark.md
+++ b/docs/content/5.integrations/postmark.md
@@ -66,7 +66,7 @@ export default defineEventHandler(async (event) => {
     From: 'you@example.com',
     To: 'user@gmail.com',
     Subject: 'hello world',
-    HtmlBody: template,
+    HtmlBody: template.html,
   };
 
   await client.sendEmail(options);
@@ -97,7 +97,7 @@ app.post('/api/send-email', async (req, res) => {
     From: 'you@example.com',
     To: 'user@gmail.com',
     Subject: 'hello world',
-    HtmlBody: template,
+    HtmlBody: template.html,
   };
 
   await client.sendEmail(options);

--- a/docs/content/5.integrations/resend.md
+++ b/docs/content/5.integrations/resend.md
@@ -66,7 +66,7 @@ export default defineEventHandler(async (event) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: template,
+    html: template.html,
   };
 
   await resend.emails.send(options);
@@ -95,7 +95,7 @@ app.post('/api/send-email', async (req, res) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: template,
+    html: template.html,
   };
 
   await resend.emails.send(options);

--- a/docs/content/5.integrations/sendgrid.md
+++ b/docs/content/5.integrations/sendgrid.md
@@ -66,7 +66,7 @@ export default defineEventHandler(async (event) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: template,
+    html: template.html,
   };
 
   await sendgrid.send(options);
@@ -97,7 +97,7 @@ app.post('/api/send-email', async (req, res) => {
     from: 'you@example.com',
     to: 'user@gmail.com',
     subject: 'hello world',
-    html: template,
+    html: template.html,
   };
 
   await sendgrid.send(options);

--- a/playgrounds/nuxt/components/CodeContainer.vue
+++ b/playgrounds/nuxt/components/CodeContainer.vue
@@ -37,7 +37,7 @@ function handleDownload() {
 const languageMap = {
   vue: 'Vue',
   html: 'HTML',
-  txt: 'PlainText',
+  txt: 'Text',
 }
 
 async function handleClipboard() {

--- a/playgrounds/nuxt/components/EmailPreview.vue
+++ b/playgrounds/nuxt/components/EmailPreview.vue
@@ -64,7 +64,7 @@ watchEffect(() => {
         <UTooltip text="Change View to Desktop">
           <UButton icon="i-heroicons-computer-desktop" size="sm" color="gray" variant="solid" :trailing="false" @click="handleView('desktop')" />
         </UTooltip>
-        <UTooltip text="Get HTML/PlainText Code">
+        <UTooltip text="Get HTML/Text Code">
           <UButton
             icon="i-heroicons-code-bracket"
             size="sm"
@@ -139,7 +139,7 @@ watchEffect(() => {
           },
           {
             language: 'txt',
-            content: template.plainText,
+            content: template.text,
           },
         ]"
         @setlang="setlang"

--- a/playgrounds/nuxt/pages/preview/[slug].vue
+++ b/playgrounds/nuxt/pages/preview/[slug].vue
@@ -7,7 +7,7 @@ const { email, refresh, getEmail, getVueCode } = useEmail()
 const emailTemplate = ref({
   vue: '',
   html: '',
-  plainText: '',
+  text: '',
 })
 
 await getEmail(slug)
@@ -21,12 +21,12 @@ async function loadMarkups() {
   if (!emailFile || !email.value.component) return
   const vue = await getVueCode(email.value.component)
   const html = await useRender(emailFile, null, { pretty: true })
-  const plainText = await useRender(emailFile, null, { plainText: true })
+  const text = await useRender(emailFile, null, { text: true })
 
   emailTemplate.value = {
     vue,
     html,
-    plainText,
+    text,
   }
 }
 

--- a/playgrounds/nuxt/types/email.ts
+++ b/playgrounds/nuxt/types/email.ts
@@ -13,7 +13,7 @@ export type ActiveLang = 'vue' | 'html' | 'txt'
 export interface Template {
   vue: string
   html: string
-  plainText: string
+  text: string
 }
 
 export interface MarkupProps {

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,6 +1,6 @@
 import { extname, join, resolve } from 'node:path'
 import { readFileSync, readdirSync, statSync } from 'node:fs'
-import type { DefineConfig, Options, RenderOptions } from '../types/compiler'
+import type { DefineConfig, Options, RenderOptions, RenderedEmail } from '../types/compiler'
 import { createInitConfig } from './config'
 import { templateRender } from './template'
 
@@ -11,7 +11,7 @@ export const config: DefineConfig = (dir: string, config: Options = {}) => {
   const components = getAllVueComponents(dir)
 
   return {
-    render: (name: string, options?: RenderOptions): Promise<string> => {
+    render: (name: string, options?: RenderOptions): Promise<RenderedEmail> => {
       const path = dir ? resolve(dir, name) : name
       const source = readFile(path)
 

--- a/src/compiler/template.ts
+++ b/src/compiler/template.ts
@@ -77,7 +77,7 @@ export async function templateRender(name: string, code: SourceOptions, options?
   const markup = await renderToString(app)
   const doctype = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
   const doc = `${doctype}${cleanup(markup)}`
-  const plainText = convert(markup, {
+  const text = convert(markup, {
     selectors: [
       { selector: 'img', format: 'skip' },
       { selector: '#__vue-email-preview', format: 'skip' },
@@ -86,7 +86,7 @@ export async function templateRender(name: string, code: SourceOptions, options?
 
   return {
     html: doc,
-    plainText,
+    text,
   }
 }
 

--- a/src/composables/render.ts
+++ b/src/composables/render.ts
@@ -6,7 +6,7 @@ import { cleanup } from '../utils'
 
 export interface Options {
   pretty?: boolean
-  plainText?: boolean
+  text?: boolean
 }
 
 export interface I18n {
@@ -43,7 +43,7 @@ export async function useRender(
   params?: RenderParams | null,
   options: Options = {
     pretty: false,
-    plainText: false,
+    text: false,
   },
 ) {
   let vueI18n
@@ -71,7 +71,7 @@ export async function useRender(
 
   const markup = await renderToString(app)
 
-  if (options.plainText) {
+  if (options.text) {
     return convert(markup, {
       selectors: [
         { selector: 'img', format: 'skip' },

--- a/src/nuxt/runtime/server/services/useCompiler.ts
+++ b/src/nuxt/runtime/server/services/useCompiler.ts
@@ -16,10 +16,8 @@ const storageKey = 'assets:emails'
  *  props: {
  *    name: 'foo',
  *  },
- *  i18n: {
- *    defaultLocale: 'en',
- *    translations: {},
- *  },
+ *  locale: 'en',
+ *  translations: {},
  * })
  * ```
  */

--- a/src/nuxt/runtime/server/services/useCompiler.ts
+++ b/src/nuxt/runtime/server/services/useCompiler.ts
@@ -16,8 +16,10 @@ const storageKey = 'assets:emails'
  *  props: {
  *    name: 'foo',
  *  },
- *  locale: 'en',
- *  translations: {},
+ *  i18n: {
+ *    defaultLocale: 'en',
+ *    translations: {},
+ *  },
  * })
  * ```
  */

--- a/src/types/compiler.ts
+++ b/src/types/compiler.ts
@@ -42,7 +42,7 @@ export interface i18n {
 
 export interface RenderedEmail {
   html: string
-  plainText: string
+  text: string
 }
 
 export interface DefineConfigFunctions {

--- a/src/types/compiler.ts
+++ b/src/types/compiler.ts
@@ -40,8 +40,13 @@ export interface i18n {
   translations?: Record<string, Record<string, string>>
 }
 
+export interface RenderedEmail {
+  html: string
+  plainText: string
+}
+
 export interface DefineConfigFunctions {
-  render: (name: string, options?: RenderOptions) => Promise<string>
+  render: (name: string, options?: RenderOptions) => Promise<RenderedEmail>
 }
 
 export type DefineConfig = (dir: string, config?: Options) => DefineConfigFunctions

--- a/tests/compiler/compiler.spec.ts
+++ b/tests/compiler/compiler.spec.ts
@@ -13,7 +13,9 @@ describe('compiler', () => {
       },
     })
 
-    expect(template).toBe('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><h1>Hi! My name is Dave</h1>')
+    expect(template.html).toBe(
+      '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><h1>Hi! My name is Dave</h1>',
+    )
   })
 
   it('Should render defineComponent setup', async () => {
@@ -23,7 +25,7 @@ describe('compiler', () => {
       },
     })
 
-    expect(template).toBe(
+    expect(template.html).toBe(
       '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><section><p>Count: 2</p><p>Double: 4</p></section>',
     )
   })
@@ -35,7 +37,7 @@ describe('compiler', () => {
       },
     })
 
-    expect(template).toBe(
+    expect(template.html).toBe(
       '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><section><h1>Welcome John Doe</h1></section>',
     )
   })
@@ -60,14 +62,14 @@ describe('compiler', () => {
     const templateEn = await vuemail.render('Translate.vue', { i18n: { defaultLocale: 'en' } })
     const templateEs = await vuemail.render('Translate.vue', { i18n: { defaultLocale: 'es' } })
 
-    expect(templateEn.includes('Hello world!')).toBe(true)
-    expect(templateEs.includes('Hola mundo!')).toBe(true)
+    expect(templateEn.html.includes('Hello world!')).toBe(true)
+    expect(templateEs.html.includes('Hola mundo!')).toBe(true)
   })
 
   it('Should render with empty setup content', async () => {
     const template = await vuemail.render('TsScriptSetup.vue')
 
-    expect(template).toBe(
+    expect(template.html).toBe(
       '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><section><p>Hello</p></section>',
     )
   })
@@ -75,7 +77,7 @@ describe('compiler', () => {
   it('Auto imported components', async () => {
     const template = await vuemail.render('UseOtherComponents.vue')
 
-    expect(template).toBe(
+    expect(template.html).toBe(
       '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><section><h1 data-id="__vue-email-heading" style="" class="mx-0 my-[30px] p-0 text-center text-[24px] font-bold text-black"> Test Vue Email components </h1></section>',
     )
   })


### PR DESCRIPTION
resolves: #79 

```json
{
  "html": "<!DOCTYPE html> ...",
  "text": "Welcome John Doe"
}
```

- [x] Can generate plaintext along side html now
- [x] update docs
- [x] convert `plainText` to just `text` for easiness