### PR TITLE
fix: link to the template code in example getting started guide

### DIFF
--- a/docs/content/1.getting-started/5.examples.md
+++ b/docs/content/1.getting-started/5.examples.md
@@ -176,6 +176,6 @@ const containerImageFooter = {
 ::
 
 
-::callout{icon="i-simple-icons-github" to="https://github.com/Dave136/vue-email/blob/main/playgrounds/nuxt/emails/yelp-recent-login.vue"}
+::callout{icon="i-simple-icons-github" to="https://github.com/Dave136/vue-email/blob/main/packages/playground/emails/yelp-recent-login.vue"}
 Take a look at the email template!
 ::


### PR DESCRIPTION
This fixes a broken link in the docs pointing to example template file