### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/packages/nuxt/src/runtime/templates/vue-email.ts
+++ b/packages/nuxt/src/runtime/templates/vue-email.ts
@@ -1,6 +1,6 @@
 import { VueEmailPlugin } from '@vue-email/core'
 import type { VueEmailPluginOptions } from '@vue-email/types'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const config = useRuntimeConfig()


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.