### PR TITLE
Render: Support dynamic component registration

### DIFF
--- a/packages/render/src/shared/options.ts
+++ b/packages/render/src/shared/options.ts
@@ -1,4 +1,5 @@
 import type { HtmlToTextOptions } from "html-to-text";
+import { Component, DefineComponent } from 'vue'
 
 export type Options = {
   pretty?: boolean;
@@ -15,5 +16,6 @@ export type Options = {
        * @see https://github.com/html-to-text/node-html-to-text
        */
       htmlToTextOptions?: HtmlToTextOptions;
+      components?:  { [name: string]: Component | DefineComponent }
     }
   );

--- a/packages/render/src/shared/render.ts
+++ b/packages/render/src/shared/render.ts
@@ -33,6 +33,12 @@ export async function render<T extends Component>(
   const doctype = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
   const App = createSSRApp(component, props || {})
 
+  if (options && options.components) {
+    Object.keys(options.components).forEach(key => {
+      App.component(key, options.components[key])
+    });
+  }
+
   const markup = await renderToString(App)
   if (options?.plainText) {
     return convert(markup, {


### PR DESCRIPTION
I am using the Vue Email library and would like to propose an enhancement that could streamline the process of component registration. Currently, the library requires manual imports of components for each email template. I have made an improvement by adding support for dynamic component registration via options.components.

```ts
// Usage
import * as components from '@vue-email/components';

const components = Object.keys(components);

const html = await render(template, {
    data: contentData,
}, {
    pretty: true,
    components: components,
});
```