### PR TITLE
fix(tailwind): add `container` in blocklist

### DIFF
--- a/packages/tailwind/src/index.ts
+++ b/packages/tailwind/src/index.ts
@@ -35,7 +35,7 @@ export const Tailwind = defineComponent({
     )
 
     const nonMediaQueryCSS = markupCSS.replaceAll(
-      /@media\s*\(.*\)\s*{\s*\.(.*)\s*{[\s\S]*}\s*}/gm,
+      /@media\s*\(.*?\)\s*{[^{}]*({[^{}]*}[^{}a]*)*}/gm,
       (mediaQuery: any, _className: any) => {
         headStyles.push(
           mediaQuery

--- a/packages/tailwind/tailwind.spec.ts
+++ b/packages/tailwind/tailwind.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'vue'
 import { render } from "@vue-email/render";
+import { Body } from '@vue-email/body'
+import { Html } from '@vue-email/html'
+import { Head } from '@vue-email/head'
 import { Tailwind } from './src/index'
 // import TailwindTest from '../components/TailwindTest.vue'
 
@@ -44,6 +47,40 @@ describe('tailwind component', () => {
 
       expect(actualOutput).toMatchInlineSnapshot(
         '"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div class="bg-test text-white" style="background-color: rgb(252,186,3); color: rgb(255,255,255);">Hello world</div><div class="bg-test" style="color: rgb(255,255,255); background-color: rgb(252,186,3);">custom background</div>"',
+      )
+    })
+
+    it('should render with inline Tailwind styles that contain @media styles', async () => {
+      const component = h(Tailwind, [
+          h(Html, [
+            h(Head),
+            h(Body,  { class: 'w-full max-w-[650px] md:p-7'}, [
+              h(
+                'div',
+                [
+                  // Tailwind generate `container` class that has @media styles
+                  // @see https://tailwindcss.com/docs/content-configuration#discarding-classes
+                  'The text contains a container word that generate Tailwind class `.container`'
+                ]
+              ),
+              h(
+                'div',
+                {
+                  class: 'text-[#42B883]',
+                },
+                [
+                  'custom background'
+                ]
+              ),
+            ])
+        ])
+      ])
+
+
+      const actualOutput = await render(component)
+
+      expect(actualOutput).toMatchInlineSnapshot(
+        `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html lang="en" dir="ltr"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="x-apple-disable-message-reformatting"></meta></meta></head><body class="md:p-7" style="width: 100%; max-width: 650px;"><div>The text contains a container word that generate Tailwind class \`.container\`</div><div class="text-[#42B883]" style="color: rgb(66,184,131);">custom background</div></body></html>"`,
       )
     })
   })


### PR DESCRIPTION
resolves: #198 

I found a similar case mentioned in the official Tailwind documentation:
https://tailwindcss.com/docs/content-configuration#discarding-classes

This may not prevent all possible cases, but at least the error with the `container` word combination should not bother you anymore