### PR TITLE
fix(tailwind): regex for nonMediaQueryCSS

### DIFF
--- a/packages/tailwind/src/index.ts
+++ b/packages/tailwind/src/index.ts
@@ -36,7 +36,7 @@ export const Tailwind = defineComponent({
     )
 
     const nonMediaQueryCSS = markupCSS.replaceAll(
-      /@media\s*\(.*\)\s*{\s*\.(.*)\s*{[\s\S]*}\s*}/gm,
+      /@media\s*\(.*?\)\s*{[^{}]*({[^{}]*}[^{}a]*)*}/gm,
       (mediaQuery: any, _className: any) => {
         headStyles.push(
           mediaQuery

--- a/packages/tailwind/tailwind.spec.ts
+++ b/packages/tailwind/tailwind.spec.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'vue'
 import { render } from "@vue-email/render";
 import { Tailwind } from './src/index'
+import { Html } from "@vue-email/html";
+import { Head } from "@vue-email/head";
+import { Body } from "@vue-email/body";
 // import TailwindTest from '../components/TailwindTest.vue'
 
 describe('tailwind component', () => {
@@ -44,6 +47,26 @@ describe('tailwind component', () => {
 
       expect(actualOutput).toMatchInlineSnapshot(
         '"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div class="bg-test text-white" style="background-color: rgb(252,186,3); color: rgb(255,255,255);">Hello world</div><div class="bg-test" style="color: rgb(255,255,255); background-color: rgb(252,186,3);">custom background</div>"',
+      )
+    })
+  })
+
+  describe('class styles', () => {
+    it.only('should render with Tailwind utility classes', async () => {
+      const component = h(Tailwind, [
+        h(Html, [
+          h(Head),
+          h(Body, [
+            h('div', { class: 'container' }, [
+              h('div', { class: 'hidden sm:block text-[#ccc]' })
+            ])
+          ])
+        ])
+      ])
+
+      const actualOutput = await render(component)
+      expect(actualOutput).toMatchInlineSnapshot(
+        '"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html lang="en" dir="ltr"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/><meta name="x-apple-disable-message-reformatting"/></head><body><div class="container" style="width: 100%;"><div class="sm:block" style="display: none; color: rgb(204,204,204);"/></div></body></html>"',
       )
     })
   })


### PR DESCRIPTION
resolves: #198

So, what do we have.

Several cases affected the styles rendering here, and their influence isn't obvious:
1. Since the word "container" is present on the page, Tailwind generates a whole class for it, thinking it's being used. This is described in their [documentation](https://tailwindcss.com/docs/content-configuration#discarding-classes), so it's worth keeping in mind that this is normal for Tailwind.
2. The example also involves classes that depend on breakpoints, such as md:p-7.

Let's consider what classes Tailwind generates based on the markup described in the test.

```scss
.container {
    width: 100%;
}

@media (min-width: 640px) {
    .container {
        max-width: 640px;
    }
}

@media (min-width: 768px) {
    .container {
        max-width: 768px;
    }
}

@media (min-width: 1024px) {
    .container {
        max-width: 1024px;
    }
}

@media (min-width: 1280px) {
    .container {
        max-width: 1280px;
    }
}

@media (min-width: 1536px) {
    .container {
        max-width: 1536px;
    }
}

.hidden {
    display: none;
}

.text-\[\#ccc\] {
    color: rgb(204, 204, 204);
}

@media (min-width: 640px) {
    .sm\:block {
        display: block;
    }
}
```

Now let's see how the classes for the nonMediaQueryCSS variable were processed before with the regex `/@media\s*\(.*\)\s*{\s*\.(.*)\s*{[\s\S]*}\s*}/gm` – https://regex101.com/r/op3l1l/1

In this case, all styles are removed, which is an error, so such an innocent word "container" breaks the appearance.

The solution here is quite simple – correcting the regex to `/@media\s*\(.*?\)\s*{[^{}]*({[^{}]*}[^{}a]*)*}/gm` – https://regex101.com/r/i8FZZW/1

P.S. Sorry, I actually had the solution for a long time, I just didn't have time to publish it 🌚
